### PR TITLE
Fix: Variogram - Add space to error message

### DIFF
--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -526,7 +526,7 @@ class Variogram(object):
         """
         # check dimensions
         if not len(values) == len(self.coordinates):  # pragma: no cover
-            raise ValueError('The length of the values array has to match' +
+            raise ValueError('The length of the values array has to match ' +
                              'the length of coordinates')
 
         # use an array


### PR DESCRIPTION
Error message needs an additional space at the end when splitting over two lines.